### PR TITLE
Update DotsLoadingView.swift

### DIFF
--- a/Dots/Classes/DotsLoadingView.swift
+++ b/Dots/Classes/DotsLoadingView.swift
@@ -42,6 +42,11 @@ public class DotsLoadingView: UIView {
     }
     
     public func show() {
+        if let sv = self.superview{
+            self.center = sv.center
+            self.startAnimation()
+            return
+        }
         if let rootViewController = UIApplication.shared.windows.first?.rootViewController {
             rootViewController.view.addSubview(self)
             self.center = rootViewController.view.center


### PR DESCRIPTION
Allow the user to show the DotsLoadingView within the view it has been added to.
If DotsLoadingView has no superView, it will behave as before.